### PR TITLE
Update TSIC.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 [arduino-tsic][1]
 ============
-This project is a library for TSIC digital temperature sensors (type 206/306 and similar). It is based on the version 2 from Rolf Wagner from 2014.03.09 which can be found on [Arduino Playground][2]. The TSIC sensors feature a very hich accuracy and can be read out roughly every 100ms using the ZACwire-rotocol, more informations can be found in the [datasheet][3]. The code is optimized for high speed and low memory consumption as described in the release notes from version 2:
+This is a fork of this library:
+https://github.com/Schm1tz1/arduino-tsic
+
+Modifications i will do in this fork:
+- increase stability of read function
+- remove supply pin, sensors will be powered permanently
+- remove some #defines
+- add a temperature conversion function for the Tsic 506
+
+This project is a library for TSIC digital temperature sensors (type 206/306/506 and similar). 
+It is based on the version 2 from Rolf Wagner from 2014.03.09 which can be found on [Arduino Playground][2]. The TSIC sensors feature a very hich accuracy and can be read out roughly every 100ms using the ZACwire-rotocol, more informations can be found in the [datasheet][3]. The code is optimized for high speed and low memory consumption as described in the release notes from version 2:
 
 - Arduino > 1.0 compatible
 - corrected offset (about +2°C)

--- a/TSIC.cpp
+++ b/TSIC.cpp
@@ -98,7 +98,7 @@ uint8_t TSIC::readSens(uint16_t *temp_value){
 	uint16_t timeout = 0;	// max value for timeout is set in .h file
 	while (TSIC_HIGH){	// wait until start bit starts
 		timeout++;
-		delayMicroseconds(5);
+		delayMicroseconds(10);
 		Cancel();
 	}
 	// Measure strobe time, a healthy sensor will go to LOW within a few loops (~60us)
@@ -108,7 +108,7 @@ uint8_t TSIC::readSens(uint16_t *temp_value){
 	while (TSIC_LOW) {    // wait for rising edge
 		strobelength++;
 		timeout++;
-		delayMicroseconds(5);
+		delayMicroseconds(10);
 		Cancel();
 	}
 	for (uint8_t i=0; i<9; i++) {
@@ -125,7 +125,7 @@ uint8_t TSIC::readSens(uint16_t *temp_value){
 		while (strobetemp--) {
 			timeout++;
 			dummy++;
-			delayMicroseconds(5);
+			delayMicroseconds(10);
 			Cancel();
 		}
 		*temp_value <<= 1;


### PR DESCRIPTION
Increased all the delayMicroseconds(5) to delayMicroseconds(10) in the readSens function.

Why?
I connected TSIC506 sensors to an arduino and used this library.
With 5 microseconds i got random parity errors about every minute.
After changing to 10 microseconds it ran for hours without a single read error.
I assume, the 5 microseconds were too short compared to the other operations done in each of the while(...) loops?
