### PR TITLE
Change output temperature by 0.1°C

### DIFF
--- a/src/TSIC.cpp
+++ b/src/TSIC.cpp
@@ -94,10 +94,10 @@ float TSIC::calc_Celsius(uint16_t *temperature16){
 	// optimized version of (temp_value/2047*(HT-LT)+LT) 
 	// calculate temperature *10, i.e. 26,4 = 264
 	if(m_sens_type==1) { // 50x sensors: LT=-10, HT=60
-		temp_value16 = ((*temperature16 * 175L) >> 9) - 100;
+		temp_value16 = ((*temperature16 * 175L) >> 9) - 99;
 	}
 	else { // 20x,30x sensors: LT=-50, HT=150
-		temp_value16 = ((*temperature16 * 250L) >> 8) - 500;
+		temp_value16 = ((*temperature16 * 250L) >> 8) - 499;
 	}
 	celsius = temp_value16 / 10 + (float) (temp_value16 % 10) / 10;	// shift comma by 1 digit e.g. 26,4°C
 	return celsius;


### PR DESCRIPTION
The output of calc_Celsius() differs by 0.1°C from the datasheet, as can be seen with this code: [https://onlinegdb.com/8t4SrBrAWO](https://onlinegdb.com/8t4SrBrAWO)
So I would suggest to change it by 0.1